### PR TITLE
Update client api to use all named params

### DIFF
--- a/lib/cellect/client/connection.rb
+++ b/lib/cellect/client/connection.rb
@@ -22,12 +22,12 @@ module Cellect
         broadcast :put, "/workflows/#{ workflow_id }/remove", querystring(subject_id: id, group_id: group_id)
       end
       
-      def load_user(id, host: host, workflow_id: workflow_id)
-        send_http host, :post, "/workflows/#{ workflow_id }/users/#{ id }/load"
+      def load_user(user_id: user_id, host: host, workflow_id: workflow_id)
+        send_http host, :post, "/workflows/#{ workflow_id }/users/#{ user_id }/load"
       end
       
-      def add_seen(id, user_id: user_id, host: host, workflow_id: workflow_id)
-        send_http host, :put, "/workflows/#{ workflow_id }/users/#{ user_id }/add_seen", querystring(subject_id: id)
+      def add_seen(subject_id: subject_id, user_id: user_id, host: host, workflow_id: workflow_id)
+        send_http host, :put, "/workflows/#{ workflow_id }/users/#{ user_id }/add_seen", querystring(subject_id: subject_id)
       end
       
       def get_subjects(user_id: user_id, host: host, workflow_id: workflow_id, limit: limit, group_id: group_id)

--- a/spec/client/connection_spec.rb
+++ b/spec/client/connection_spec.rb
@@ -53,12 +53,12 @@ module Cellect::Client
     
     it 'should load users' do
       should_send action: :post, url: 'workflows/random/users/123/load', to: 1
-      connection.load_user 123, host: '1', workflow_id: 'random'
+      connection.load_user user_id: 123, host: '1', workflow_id: 'random'
     end
     
     it 'should add seen subjects' do
       should_send action: :put, url: 'workflows/random/users/123/add_seen?subject_id=456', to: 1
-      connection.add_seen 456, host: '1', user_id: 123, workflow_id: 'random'
+      connection.add_seen subject_id: 456, host: '1', user_id: 123, workflow_id: 'random'
     end
 
     it 'should get subjects' do


### PR DESCRIPTION
This is a super trivial change. I'd just like to update the cellect interactions in the rails app to use white-listed params, and this will make it a little easier to pass the white-listed params to those methods. 
