### PR TITLE
Update for ruby 2.2.0

### DIFF
--- a/cellect-client.gemspec
+++ b/cellect-client.gemspec
@@ -28,8 +28,8 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'rack-test'
   spec.add_development_dependency 'pry'
   
-  spec.add_runtime_dependency 'celluloid', '0.16.0.pre'
-  spec.add_runtime_dependency 'celluloid-io', '0.16.0.pre'
+  spec.add_runtime_dependency 'celluloid', '0.16.0'
+  spec.add_runtime_dependency 'celluloid-io', '0.16.0'
   spec.add_runtime_dependency 'http', '~> 0.6'
   spec.add_runtime_dependency 'zk', '~> 1.9'
   spec.add_runtime_dependency 'multi_json', '~> 1.10.1'

--- a/cellect-server.gemspec
+++ b/cellect-server.gemspec
@@ -35,6 +35,6 @@ Gem::Specification.new do |spec|
   spec.add_runtime_dependency 'celluloid', '0.16.0.pre'
   spec.add_runtime_dependency 'celluloid-io', '0.16.0.pre'
   spec.add_runtime_dependency 'http', '~> 0.6'
-  spec.add_runtime_dependency 'zk', '~> 1.9'
+  spec.add_runtime_dependency 'zk', '~> 1.9.5'
   spec.add_runtime_dependency 'grape', '~> 0.7'
 end

--- a/cellect-server.gemspec
+++ b/cellect-server.gemspec
@@ -32,8 +32,8 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'connection_pool', '~> 2.0'
   
   spec.add_runtime_dependency 'diff_set'
-  spec.add_runtime_dependency 'celluloid', '0.16.0.pre'
-  spec.add_runtime_dependency 'celluloid-io', '0.16.0.pre'
+  spec.add_runtime_dependency 'celluloid', '0.16.0'
+  spec.add_runtime_dependency 'celluloid-io', '0.16.0'
   spec.add_runtime_dependency 'http', '~> 0.6'
   spec.add_runtime_dependency 'zk', '~> 1.9.5'
   spec.add_runtime_dependency 'grape', '~> 0.7'

--- a/lib/cellect/client/connection.rb
+++ b/lib/cellect/client/connection.rb
@@ -16,23 +16,23 @@ module Cellect
         broadcast :delete, "/workflows/#{ id }"
       end
       
-      def add_subject(id, workflow_id: workflow_id, group_id: nil, priority: nil)
+      def add_subject(id, workflow_id: nil, group_id: nil, priority: nil)
         broadcast :put, "/workflows/#{ workflow_id }/add", querystring(subject_id: id, group_id: group_id, priority: priority)
       end
       
-      def remove_subject(id, workflow_id: workflow_id, group_id: nil)
+      def remove_subject(id, workflow_id: nil, group_id: nil)
         broadcast :put, "/workflows/#{ workflow_id }/remove", querystring(subject_id: id, group_id: group_id)
       end
       
-      def load_user(user_id: user_id, host: host, workflow_id: workflow_id)
+      def load_user(user_id: nil, host: nil, workflow_id: nil)
         send_http host, :post, "/workflows/#{ workflow_id }/users/#{ user_id }/load"
       end
       
-      def add_seen(subject_id: subject_id, user_id: user_id, host: host, workflow_id: workflow_id)
+      def add_seen(subject_id: nil, user_id: nil, host: nil, workflow_id: nil)
         send_http host, :put, "/workflows/#{ workflow_id }/users/#{ user_id }/add_seen", querystring(subject_id: subject_id)
       end
       
-      def get_subjects(user_id: user_id, host: host, workflow_id: workflow_id, limit: limit, group_id: group_id)
+      def get_subjects(user_id: nil, host: nil, workflow_id: nil, limit: nil, group_id: nil)
         response = send_http host, :get, "/workflows/#{ workflow_id }", querystring(user_id: user_id, group_id: group_id, limit: limit)
         ensure_valid_response response
         MultiJson.load response.body

--- a/spec/client/connection_spec.rb
+++ b/spec/client/connection_spec.rb
@@ -8,11 +8,11 @@ module Cellect::Client
       allow(Cellect::Client.node_set).to receive(:nodes).and_return 'a' => '1', 'b' => '2'
     end
     
-    def should_send(action: action, url: url, to: to)
+    def should_send(action: nil, url: nil, to: nil)
       expect(HTTP).to receive(:send).with(action, "http://#{ to }/#{ url }", socket_class: Celluloid::IO::TCPSocket).and_return(HTTP::Response.new(200, nil, nil, "{ \"this response\": \"intentionally blank\" }"))
     end
     
-    def should_broadcast(action: action, url: url)
+    def should_broadcast(action: nil, url: nil)
       [1, 2].each{ |i| should_send action: action, url: url, to: i }
     end
     

--- a/spec/support/cellect_helper.rb
+++ b/spec/support/cellect_helper.rb
@@ -1,7 +1,7 @@
 require 'timeout'
 
 module CellectHelper
-  def pass_until(obj, is: is)
+  def pass_until(obj, is: nil)
     Timeout::timeout(1) do
       Thread.pass until obj.state == is
     end


### PR DESCRIPTION
* Update zk gem
* Remove circular argument references

I'd like to get this in so I can start testing Panoptes on JRuby 9.0.0.0, which should offer several performance improvements. 