### PR TITLE
Add support for lazy loading workflows

### DIFF
--- a/lib/cellect/server/adapters/default.rb
+++ b/lib/cellect/server/adapters/default.rb
@@ -10,7 +10,7 @@ module Cellect
         #     'pairwise' => false,
         #     'grouped' => false
         #   }, ...]
-        def workflow_list
+        def workflow_list(*names)
           raise NotImplementedError
         end
         
@@ -34,8 +34,8 @@ module Cellect
           raise NotImplementedError
         end
         
-        def load_workflows
-          workflow_list.each{ |workflow_info| load_workflow workflow_info }
+        def load_workflows(*names)
+          workflow_list(*names).each{ |workflow_info| load_workflow workflow_info }
         end
         
         def load_workflow(args)
@@ -52,7 +52,8 @@ module Cellect
         
         def workflow_for(opts = { })
           workflow_klass = opts.fetch('grouped', false) ? GroupedWorkflow : Workflow
-          workflow_klass[opts['name'], pairwise: opts['pairwise'], prioritized: opts['prioritized']]
+          workflow_klass[opts['name']] = opts 
+          workflow_klass[opts['name']]
         end
       end
     end

--- a/lib/cellect/server/adapters/postgres.rb
+++ b/lib/cellect/server/adapters/postgres.rb
@@ -11,9 +11,18 @@ module Cellect
           end
         end
 
-        def workflow_list
+        def workflow_list(*names)
           with_pg do |pg|
-            pg.exec('SELECT * FROM workflows').collect do |row|
+            statement = 'SELECT * FROM workflows'
+            statement += case names.length
+                         when 0
+                           ""
+                         when 1
+                           "WHERE \"workflows\".\"id\" = #{ names.first }"
+                         else
+                           "WHERE \"workflows\".\"id\" IN (#{ names.join(',') })"
+                         end
+            pg.exec(statement).collect do |row|
               {
                 'id' => row['id'].to_i,
                 'name' => row['id'],

--- a/lib/cellect/server/workflow.rb
+++ b/lib/cellect/server/workflow.rb
@@ -5,11 +5,20 @@ module Cellect
       
       attr_accessor :name, :users, :subjects, :state
       attr_accessor :pairwise, :prioritized
+
+      def self.name_to_key(name)
+        "workflow_#{ name }".to_sym
+      end
       
-      def self.[](name, pairwise: false, prioritized: false)
-        key = "workflow_#{ name }".to_sym
-        Actor[key] ||= supervise name, pairwise: pairwise, prioritized: prioritized
-        Actor[key].actors.first
+      def self.[](name)
+        Actor[name_to_key(name)].actors.first
+      rescue StandardError => e
+        Cellect::Server.adapter.load_workflows(name)
+        Actor[name_to_key(name)].actors.first
+      end
+
+      def self.[]=(name, opts)
+        Actor[name_to_key(name)] = supervise name, pairwise: opts['pairwise'], prioritized: opts['prioritized']
       end
       
       def self.names

--- a/spec/server/workflow_spec.rb
+++ b/spec/server/workflow_spec.rb
@@ -2,13 +2,19 @@ require 'spec_helper'
 
 module Cellect::Server
   describe Workflow do
+    it "should try to load workflows that aren't loaded" do
+      fake_actors = double({actors: []})
+      expect(Cellect::Server.adapter).to receive(:load_workflows).with("random").and_call_original
+      Workflow["random"]
+    end
+    
     SET_TYPES.each do |workflow_type|
       context workflow_type do
         it_behaves_like 'workflow', :workflow
         let(:workflow){ Workflow[workflow_type] }
         let(:user){ workflow.user 123 }
         before(:each){ pass_until workflow, is: :ready }
-        
+
         it 'should provide unseen for users' do
           expect(workflow.subjects).to receive(:subtract).with user.seen, 3
           workflow.unseen_for 123, limit: 3
@@ -35,8 +41,8 @@ module Cellect::Server
         end
         
         it 'should remove subjects' do
-          expect(workflow.subjects).to receive(:add).with 123
-          workflow.add subject_id: 123
+          expect(workflow.subjects).to receive(:remove).with 123
+          workflow.remove subject_id: 123
         end
         
         it 'should be notified of a user ttl expiry' do

--- a/spec/support/shared_examples_for_workflow.rb
+++ b/spec/support/shared_examples_for_workflow.rb
@@ -6,8 +6,8 @@ shared_examples_for 'workflow' do |name|
   end
   
   it 'should add singleton instances to the registry' do
-    expect(obj.class[:foo]).to be_a_kind_of Cellect::Server::Workflow
-    expect(obj.class[:foo].object_id).to eq obj.class[:foo].object_id
+    expect(obj.class[obj.name]).to be_a_kind_of Cellect::Server::Workflow
+    expect(obj.class[obj.name].object_id).to eq obj.class[obj.name].object_id
   end
   
   it 'should initialize empty' do

--- a/spec/support/spec_adapter.rb
+++ b/spec/support/spec_adapter.rb
@@ -1,8 +1,12 @@
 require 'oj'
 
 class SpecAdapter < Cellect::Server::Adapters::Default
-  def workflow_list
-    fixtures.values
+  def workflow_list(*names)
+    if names.empty?
+      fixtures.values
+    else
+      fixtures.values_at(*names)
+    end
   end
   
   def load_data_for(workflow_name)


### PR DESCRIPTION
It doesn't handle the case where the workflow can't be found at the moment, but that shouldn't happen  given the level of integration between Cellect and Panoptes, so I figured we could kick the can the down the road until we needed to decide what should happen.