### PR TITLE
Defer workflow data loading to prevent re-entrant calls

### DIFF
--- a/lib/cellect/server/adapters/default.rb
+++ b/lib/cellect/server/adapters/default.rb
@@ -57,7 +57,8 @@ module Cellect
 
         def workflow_for(opts = { })
           workflow_klass = opts.fetch('grouped', false) ? GroupedWorkflow : Workflow
-          workflow_klass[opts['name']] = opts 
+          workflow_klass[opts['name']] = opts
+          workflow_klass[opts['name']].load_data
           workflow_klass[opts['name']]
         end
       end

--- a/lib/cellect/server/api.rb
+++ b/lib/cellect/server/api.rb
@@ -21,7 +21,7 @@ module Cellect
         {
           memory: usage.call('%mem'),
           cpu: usage.call('%cpu'),
-          instance: instance.id,
+          instance: instance.try(:id),
           status: Cellect::Server.adapter.status.merge({
             workflows_ready: Cellect::Server.ready?,
             workflows: Workflow.all.map(&:status)

--- a/lib/cellect/server/workflow.rb
+++ b/lib/cellect/server/workflow.rb
@@ -42,7 +42,6 @@ module Cellect
         self.pairwise = !!pairwise
         self.prioritized = !!prioritized
         self.subjects = set_klass.new
-        load_data
       end
 
       # Loads subjects from the adapter


### PR DESCRIPTION
This prevents `Workflow#load_data` from being called while the data is currently loading.