### PR TITLE
better data loading mechanisms

### DIFF
--- a/lib/cellect/server/api.rb
+++ b/lib/cellect/server/api.rb
@@ -56,7 +56,7 @@ module Cellect
           # Reloads the workflow from the adapter
           post :reload do
             return four_oh_four unless workflow
-            workflow.async.load_data
+            workflow.async.reload_data
           end
 
           # DELETE /workflows/:workflow_id

--- a/lib/cellect/server/api.rb
+++ b/lib/cellect/server/api.rb
@@ -10,7 +10,7 @@ module Cellect
       require 'cellect/server/api/users'
 
       # GET /stats
-      # 
+      #
       # Provides system load information
       get :stats do
         instance = Attention.instance
@@ -32,7 +32,7 @@ module Cellect
       resources :workflows do
 
         # GET /workflows
-        # 
+        #
         # Returns a list of available workflows
         get do
           Cellect::Server.adapter.workflow_list
@@ -44,7 +44,7 @@ module Cellect
           mount Users
 
           # GET /workflows/:workflow_id/status
-          # 
+          #
           # Returns the workflow's status
           get :status do
             return four_oh_four unless workflow
@@ -52,7 +52,7 @@ module Cellect
           end
 
           # POST /workflows/:workflow_id/reload
-          # 
+          #
           # Reloads the workflow from the adapter
           post :reload do
             return four_oh_four unless workflow
@@ -60,7 +60,7 @@ module Cellect
           end
 
           # DELETE /workflows/:workflow_id
-          # 
+          #
           # Not implemented
           delete do
             # delete a workflow (maybe?)

--- a/lib/cellect/server/user.rb
+++ b/lib/cellect/server/user.rb
@@ -18,11 +18,13 @@ module Cellect
         self.seen = DiffSet::RandomSet.new
         monitor Workflow[workflow_name]
         @ttl = ttl
-        load_data
+        self.state = :initializing
       end
 
       # Load the seen subjects for a user and restarts the TTL
       def load_data
+        return if self.state == :ready
+        self.state = :loading
         data = Cellect::Server.adapter.load_user(workflow_name, id) || []
         data.each do |subject_id|
           @seen.add subject_id

--- a/lib/cellect/server/workflow.rb
+++ b/lib/cellect/server/workflow.rb
@@ -56,6 +56,18 @@ module Cellect
         self.state = :ready
       end
 
+      # Reloads subjects from the adapter
+      def reload_data
+        return if self.state == :reloading
+        self.state = :reloading
+        new_data = set_klass.new
+        Cellect::Server.adapter.load_data_for(name).each do |hash|
+          new_data.add hash['id'], hash['priority']
+        end
+        self.subjects = new_data
+        self.state = :ready
+      end
+
       # Look up and/or load a user
       def user(id)
         self.users[id] ||= User.supervise id, workflow_name: name

--- a/lib/cellect/server/workflow.rb
+++ b/lib/cellect/server/workflow.rb
@@ -59,7 +59,9 @@ module Cellect
       # Look up and/or load a user
       def user(id)
         self.users[id] ||= User.supervise id, workflow_name: name
-        users[id].actors.first
+        user = self.users[id].actors.first
+        user.load_data
+        user
       end
 
       # Get unseen subjects for a user

--- a/lib/cellect/server/workflow.rb
+++ b/lib/cellect/server/workflow.rb
@@ -8,6 +8,8 @@ module Cellect
       end
       self.workflow_names = { }
 
+      finalizer :cancel_reload_timer
+
       attr_accessor :name, :users, :subjects, :state, :pairwise,
         :prioritized, :can_reload, :reload_timer
 
@@ -200,6 +202,12 @@ module Cellect
         self.reload_timer = after(RELOAD_TIMEOUT) do
           self.can_reload = true
         end
+      end
+
+      # Releases the reload timer
+      def cancel_reload_timer
+        reload_timer.cancel if reload_timer
+        self.reload_timer = nil
       end
     end
   end

--- a/lib/cellect/server/workflow.rb
+++ b/lib/cellect/server/workflow.rb
@@ -14,7 +14,7 @@ module Cellect
         :prioritized, :can_reload, :reload_timer
 
       LOADING_STATES = [ :reloading, :loading ].freeze
-      RELOAD_TIMEOUT = ENV.fetch('reload_timer', 600).to_i.freeze
+      RELOAD_TIMEOUT = ENV.fetch('RELOAD_TIMER', 600).to_i.freeze
 
       # Look up and/or load a workflow
       def self.[](name)

--- a/lib/cellect/server/workflow.rb
+++ b/lib/cellect/server/workflow.rb
@@ -83,7 +83,7 @@ module Cellect
       end
 
       # Get a sample of subjects for a user
-      # 
+      #
       # Accepts a hash in the form:
       #   {
       #     user_id: 123,
@@ -98,7 +98,7 @@ module Cellect
       end
 
       # Adds or updates a subject
-      # 
+      #
       # Accepts a hash in the form:
       # {
       #   subject_id: 1,
@@ -113,7 +113,7 @@ module Cellect
       end
 
       # Removes a subject
-      # 
+      #
       # Accepts a hash in the form:
       # {
       #   subject_id: 1

--- a/lib/cellect/server/workflow.rb
+++ b/lib/cellect/server/workflow.rb
@@ -42,11 +42,13 @@ module Cellect
         self.pairwise = !!pairwise
         self.prioritized = !!prioritized
         self.subjects = set_klass.new
+        self.state = :initializing
       end
 
       # Loads subjects from the adapter
       def load_data
-        self.state = :initializing
+        return if self.state == :ready
+        self.state = :loading
         self.subjects = set_klass.new
         Cellect::Server.adapter.load_data_for(name).each do |hash|
           subjects.add hash['id'], hash['priority']

--- a/spec/cellect/server/api/reload_spec.rb
+++ b/spec/cellect/server/api/reload_spec.rb
@@ -1,0 +1,26 @@
+require 'spec_helper'
+
+module Cellect::Server
+  describe API do
+    include_context 'API'
+
+    { 'Ungrouped' => nil, 'Grouped' => 'grouped' }.each_pair do |grouping_type, grouping|
+      SET_TYPES.shuffle.each do |set_type|
+        context "#{ grouping_type } #{ set_type }" do
+          let(:workflow_type){ [grouping, set_type].compact.join '_' }
+          let(:workflow){ Workflow[workflow_type] }
+          before(:each){ pass_until_state_of workflow, is: :ready }
+
+          it 'should call reload_data' do
+            async_workflow = double
+            expect(workflow).to receive(:async).and_return async_workflow
+            expect(async_workflow).to receive(:reload_data)
+            post "/workflows/#{ workflow_type }/reload"
+            expect(last_response.status).to eq 201
+            expect(json).to be_nil
+          end
+        end
+      end
+    end
+  end
+end

--- a/spec/cellect/server/grouped_workflow_spec.rb
+++ b/spec/cellect/server/grouped_workflow_spec.rb
@@ -4,11 +4,17 @@ module Cellect::Server
   describe GroupedWorkflow do
     SET_TYPES.collect{ |type| "grouped_#{ type }" }.each do |workflow_type|
       context workflow_type do
-        it_behaves_like 'workflow', :workflow
         let(:workflow){ GroupedWorkflow[workflow_type] }
         let(:user){ workflow.user 123 }
         let(:set_klass){ workflow.prioritized? ? DiffSet::PrioritySet : DiffSet::RandomSet }
-        before(:each){ pass_until_state_of workflow, is: :ready }
+
+        before do
+          pass_until_state_of workflow, is: :ready
+        end
+
+        it_behaves_like 'workflow', :workflow do
+          let(:obj) { workflow }
+        end
 
         it 'should provide unseen from a random group for users' do
           workflow.groups = { }

--- a/spec/cellect/server/grouped_workflow_spec.rb
+++ b/spec/cellect/server/grouped_workflow_spec.rb
@@ -4,20 +4,16 @@ module Cellect::Server
   describe GroupedWorkflow do
     SET_TYPES.collect{ |type| "grouped_#{ type }" }.each do |workflow_type|
       context workflow_type do
-        let(:workflow){ GroupedWorkflow[workflow_type] }
+        let(:workflow){ GroupedWorkflow.new(workflow_type) }
         let(:user){ workflow.user 123 }
         let(:set_klass){ workflow.prioritized? ? DiffSet::PrioritySet : DiffSet::RandomSet }
-
-        before do
-          pass_until_state_of workflow, is: :ready
-        end
 
         it_behaves_like 'workflow', :workflow do
           let(:obj) { workflow }
         end
 
         it 'should provide unseen from a random group for users' do
-          workflow.groups = { }
+          workflow.subjects = { }
           workflow.groups[1] = set_klass.new
           expect(workflow.groups[1]).to receive(:subtract).with user.seen, 3
           workflow.unseen_for 123, limit: 3
@@ -30,7 +26,7 @@ module Cellect::Server
         end
 
         it 'should sample subjects from a random group without a user' do
-          workflow.groups = { }
+          workflow.subjects = { }
           workflow.groups[1] = set_klass.new
           expect(workflow.group(1)).to receive(:sample).with 3
           workflow.sample limit: 3
@@ -43,7 +39,7 @@ module Cellect::Server
         end
 
         it 'should sample subjects from a random group for a user' do
-          workflow.groups = { }
+          workflow.subjects = { }
           workflow.groups[1] = set_klass.new
           expect(workflow.groups[1]).to receive(:subtract).with user.seen, 3
           workflow.sample user_id: 123, limit: 3

--- a/spec/cellect/server/user_spec.rb
+++ b/spec/cellect/server/user_spec.rb
@@ -28,5 +28,24 @@ module Cellect::Server
       user.ttl_expired!
       expect(user.ttl_timer).to be_nil
     end
+
+    describe '#load_data' do
+      it 'should request data from the adapater' do
+        expect(Cellect::Server.adapter)
+          .to receive(:load_user)
+          .with(user.workflow_name, user.id)
+          .and_return([])
+        user.load_data
+      end
+
+      it 'should add data to seens' do
+        expect { user.load_data }.to change { user.seen.size }
+      end
+
+      it 'should not add new subjects when already loaded' do
+        user.load_data
+        expect { user.load_data }.not_to change { user.seen.size }
+      end
+    end
   end
 end

--- a/spec/cellect/server/workflow_spec.rb
+++ b/spec/cellect/server/workflow_spec.rb
@@ -63,25 +63,6 @@ module Cellect::Server
         it 'should not be grouped' do
           expect(workflow).to_not be_grouped
         end
-
-        describe '#load_data' do
-          it 'should request data from the adapater' do
-            expect(Cellect::Server.adapter)
-              .to receive(:load_data_for)
-              .with(workflow.name)
-              .and_return([])
-            workflow.load_data
-          end
-
-          it 'should add data to subjects' do
-            expect { workflow.load_data }.to change { workflow.subjects }
-          end
-
-          it 'should not reload subjects when already loaded' do
-            workflow.load_data
-            expect { workflow.load_data }.not_to change { workflow.subjects }
-          end
-        end
       end
     end
   end

--- a/spec/cellect/server/workflow_spec.rb
+++ b/spec/cellect/server/workflow_spec.rb
@@ -82,6 +82,28 @@ module Cellect::Server
             expect { workflow.load_data }.not_to change { workflow.subjects }
           end
         end
+
+        describe '#reload_data' do
+          let(:adapter) { Cellect::Server.adapter }
+
+          it 'should request data from the adapater' do
+            expect(adapter)
+              .to receive(:load_data_for)
+              .with(workflow.name)
+              .and_return([])
+            workflow.reload_data
+          end
+
+          it 'should add data to subjects' do
+            expect { workflow.reload_data }.to change { workflow.subjects }
+          end
+
+          it 'should not reload subjects when state is reloading' do
+            workflow.state = :reloading
+            expect(adapter).not_to receive(:load_data_for)
+            workflow.reload_data
+          end
+        end
       end
     end
   end

--- a/spec/cellect/server/workflow_spec.rb
+++ b/spec/cellect/server/workflow_spec.rb
@@ -9,10 +9,15 @@ module Cellect::Server
 
     SET_TYPES.each do |workflow_type|
       context workflow_type do
-        it_behaves_like 'workflow', :workflow
         let(:workflow){ Workflow[workflow_type] }
         let(:user){ workflow.user 123 }
-        before(:each){ pass_until_state_of workflow, is: :ready }
+        before do
+          pass_until_state_of workflow, is: :ready
+        end
+
+        it_behaves_like 'workflow', :workflow do
+          let(:obj) { workflow }
+        end
 
         it 'should provide unseen for users' do
           expect(workflow.subjects).to receive(:subtract).with user.seen, 3

--- a/spec/cellect/server/workflow_spec.rb
+++ b/spec/cellect/server/workflow_spec.rb
@@ -66,6 +66,25 @@ module Cellect::Server
         it 'should not be grouped' do
           expect(workflow).to_not be_grouped
         end
+
+        describe '#load_data' do
+          it 'should request data from the adapater' do
+            expect(Cellect::Server.adapter)
+              .to receive(:load_data_for)
+              .with(workflow.name)
+              .and_return([])
+            workflow.load_data
+          end
+
+          it 'should add data to subjects' do
+            expect { workflow.load_data }.to change { workflow.subjects }
+          end
+
+          it 'should not reload subjects when already loaded' do
+            workflow.load_data
+            expect { workflow.load_data }.not_to change { workflow.subjects }
+          end
+        end
       end
     end
   end

--- a/spec/cellect/server/workflow_spec.rb
+++ b/spec/cellect/server/workflow_spec.rb
@@ -9,11 +9,8 @@ module Cellect::Server
 
     SET_TYPES.each do |workflow_type|
       context workflow_type do
-        let(:workflow){ Workflow[workflow_type] }
-        let(:user){ workflow.user 123 }
-        before do
-          pass_until_state_of workflow, is: :ready
-        end
+        let(:workflow) { Workflow.new(workflow_type) }
+        let(:user) { workflow.user 123 }
 
         it_behaves_like 'workflow', :workflow do
           let(:obj) { workflow }
@@ -51,7 +48,7 @@ module Cellect::Server
 
         it 'should be notified of a user ttl expiry' do
           async_workflow = double
-          expect(workflow).to receive(:async).and_return async_workflow
+          expect(Workflow[workflow.name]).to receive(:async).and_return async_workflow
           expect(async_workflow).to receive(:remove_user).with user.id
           user.ttl_expired!
         end

--- a/spec/cellect/server/workflow_spec.rb
+++ b/spec/cellect/server/workflow_spec.rb
@@ -82,28 +82,6 @@ module Cellect::Server
             expect { workflow.load_data }.not_to change { workflow.subjects }
           end
         end
-
-        describe '#reload_data' do
-          let(:adapter) { Cellect::Server.adapter }
-
-          it 'should request data from the adapater' do
-            expect(adapter)
-              .to receive(:load_data_for)
-              .with(workflow.name)
-              .and_return([])
-            workflow.reload_data
-          end
-
-          it 'should add data to subjects' do
-            expect { workflow.reload_data }.to change { workflow.subjects }
-          end
-
-          it 'should not reload subjects when state is reloading' do
-            workflow.state = :reloading
-            expect(adapter).not_to receive(:load_data_for)
-            workflow.reload_data
-          end
-        end
       end
     end
   end

--- a/spec/support/shared_examples_for_workflow.rb
+++ b/spec/support/shared_examples_for_workflow.rb
@@ -1,10 +1,4 @@
 shared_examples_for 'workflow' do |name|
-  let(:obj){ send name }
-
-  before(:each) do
-    Cellect::Server.adapter.load_workflow obj.name
-  end
-
   it 'should add singleton instances to the registry' do
     expect(obj.class[obj.name]).to be_a_kind_of Cellect::Server::Workflow
     expect(obj.class[obj.name].object_id).to eq obj.class[obj.name].object_id

--- a/spec/support/shared_examples_for_workflow.rb
+++ b/spec/support/shared_examples_for_workflow.rb
@@ -22,15 +22,6 @@ shared_examples_for 'workflow' do |name|
     expect(obj.users.keys).to include 1
   end
 
-  describe "#finalizer" do
-
-    it "should cancel reload_timer" do
-      obj.load_data
-      expect(obj.reload_timer).to receive(:cancel).and_call_original
-      obj.terminate
-    end
-  end
-
   describe '#load_data' do
     it 'should request data from the adapater' do
       expect(Cellect::Server.adapter)
@@ -55,7 +46,8 @@ shared_examples_for 'workflow' do |name|
 
     context "able to reload" do
       before do
-        obj.can_reload = true
+        obj.can_reload_at = Time.now - 1
+        obj.state = :ready
       end
 
       it 'should request data from the adapater' do
@@ -94,9 +86,9 @@ shared_examples_for 'workflow' do |name|
         obj.reload_data
       end
 
-      context "when the reload timer has reset" do
+      context "when reload time gaurds has past" do
         it 'should allow reloading after timer has reset' do
-          obj.can_reload = true
+          obj.can_reload_at = Time.now - 1
           expect(adapter).to receive(:load_data_for).and_call_original
           obj.reload_data
         end

--- a/spec/support/shared_examples_for_workflow.rb
+++ b/spec/support/shared_examples_for_workflow.rb
@@ -18,6 +18,25 @@ shared_examples_for 'workflow' do |name|
     expect(obj.users.keys).to include 1
   end
 
+  describe '#load_data' do
+    it 'should request data from the adapater' do
+      expect(Cellect::Server.adapter)
+        .to receive(:load_data_for)
+        .with(obj.name)
+        .and_return([])
+      obj.load_data
+    end
+
+    it 'should add data to subjects' do
+      expect { obj.load_data }.to change { obj.subjects.size }
+    end
+
+    it 'should not reload subjects when in ready state' do
+      obj.state = :ready
+      expect { obj.load_data }.not_to change { obj.subjects.size }
+    end
+  end
+
   describe '#reload_data' do
     let(:adapter) { Cellect::Server.adapter }
 

--- a/spec/support/shared_examples_for_workflow.rb
+++ b/spec/support/shared_examples_for_workflow.rb
@@ -17,4 +17,26 @@ shared_examples_for 'workflow' do |name|
     expect(obj.user(1).object_id).to eq obj.user(1).object_id
     expect(obj.users.keys).to include 1
   end
+
+  describe '#reload_data' do
+    let(:adapter) { Cellect::Server.adapter }
+
+    it 'should request data from the adapater' do
+      expect(adapter)
+        .to receive(:load_data_for)
+        .with(workflow.name)
+        .and_return([])
+      workflow.reload_data
+    end
+
+    it 'should add data to subjects' do
+      expect { workflow.reload_data }.to change { workflow.subjects }
+    end
+
+    it 'should not reload subjects when state is reloading' do
+      workflow.state = :reloading
+      expect(adapter).not_to receive(:load_data_for)
+      workflow.reload_data
+    end
+  end
 end

--- a/spec/support/shared_examples_for_workflow.rb
+++ b/spec/support/shared_examples_for_workflow.rb
@@ -22,6 +22,15 @@ shared_examples_for 'workflow' do |name|
     expect(obj.users.keys).to include 1
   end
 
+  describe "#finalizer" do
+
+    it "should cancel reload_timer" do
+      obj.load_data
+      expect(obj.reload_timer).to receive(:cancel).and_call_original
+      obj.terminate
+    end
+  end
+
   describe '#load_data' do
     it 'should request data from the adapater' do
       expect(Cellect::Server.adapter)
@@ -86,7 +95,6 @@ shared_examples_for 'workflow' do |name|
       end
 
       context "when the reload timer has reset" do
-
         it 'should allow reloading after timer has reset' do
           obj.can_reload = true
           expect(adapter).to receive(:load_data_for).and_call_original


### PR DESCRIPTION
closes #57 - Modifies the workflows to load data once after initialise state and avoid reloading data if it's in the act of reloading / loading. User mimics the workflow load_data and will only do so if it's in the initialized state.

Also adds a timer guard to avoid reloading worfklows until after a timer has expired.

TODO: 
- [x] Add a timer mechanism to avoid reloading the workflow data whenever a request comes in