### PR TITLE
Non blocking async data loading while serving requests

### DIFF
--- a/lib/cellect/server.rb
+++ b/lib/cellect/server.rb
@@ -11,6 +11,7 @@ module Cellect
     require 'cellect/server/grouped_workflow'
     require 'cellect/server/user'
     require 'cellect/server/loader'
+    require 'cellect/server/grouped_loader'
     require 'cellect/server/api'
 
     class << self

--- a/lib/cellect/server.rb
+++ b/lib/cellect/server.rb
@@ -10,6 +10,7 @@ module Cellect
     require 'cellect/server/workflow'
     require 'cellect/server/grouped_workflow'
     require 'cellect/server/user'
+    require 'cellect/server/loader'
     require 'cellect/server/api'
 
     class << self

--- a/lib/cellect/server/grouped_loader.rb
+++ b/lib/cellect/server/grouped_loader.rb
@@ -4,7 +4,8 @@ module Cellect
 
       def run_load!(set)
         Cellect::Server.adapter.load_data_for(workflow.name) do |hash|
-          set[hash['id']] = hash['priority']
+          set[hash['group_id']] ||= workflow.set_klass.new
+          set[hash['group_id']].add hash['id'], hash['priority']
         end
       end
     end

--- a/lib/cellect/server/grouped_loader.rb
+++ b/lib/cellect/server/grouped_loader.rb
@@ -1,0 +1,12 @@
+module Cellect
+  module Server
+    class GroupedLoader < Loader
+
+      def run_load!(set)
+        Cellect::Server.adapter.load_data_for(workflow.name) do |hash|
+          set[hash['id']] = hash['priority']
+        end
+      end
+    end
+  end
+end

--- a/lib/cellect/server/grouped_workflow.rb
+++ b/lib/cellect/server/grouped_workflow.rb
@@ -83,11 +83,8 @@ module Cellect
 
       private
 
-      def load_adapter_data(set)
-        Cellect::Server.adapter.load_data_for(name).each do |hash|
-          set[hash['group_id']] ||= set_klass.new
-          set[hash['group_id']].add hash['id'], hash['priority']
-        end
+      def data_loader
+        GroupedLoader.new(self)
       end
     end
   end

--- a/lib/cellect/server/loader.rb
+++ b/lib/cellect/server/loader.rb
@@ -1,0 +1,38 @@
+module Cellect
+  module Server
+    class Loader
+      include Celluloid
+
+      attr_reader :workflow
+
+      def initialize(workflow)
+        @workflow = workflow
+      end
+
+      def load_data
+        run_load!(workflow.subjects)
+        mark_workflow_as_loaded
+      end
+
+      def reload_data
+        set = workflow.set_klass.new
+        run_load!(set)
+        workflow.subjects = set
+        mark_workflow_as_loaded
+      end
+
+      private
+
+      def mark_workflow_as_loaded
+        workflow.set_reload_at_time
+        workflow.state = :ready
+      end
+
+      def run_load!(set)
+        Cellect::Server.adapter.load_data_for(workflow.name).each do |hash|
+          set.add hash['id'], hash['priority']
+        end
+      end
+    end
+  end
+end

--- a/lib/cellect/server/loader.rb
+++ b/lib/cellect/server/loader.rb
@@ -14,8 +14,7 @@ module Cellect
         mark_workflow_as_loaded
       end
 
-      def reload_data
-        set = workflow.set_klass.new
+      def reload_data(set)
         run_load!(set)
         workflow.subjects = set
         mark_workflow_as_loaded

--- a/lib/cellect/server/loader.rb
+++ b/lib/cellect/server/loader.rb
@@ -28,7 +28,7 @@ module Cellect
       end
 
       def run_load!(set)
-        Cellect::Server.adapter.load_data_for(workflow.name).each do |hash|
+        Cellect::Server.adapter.load_data_for(workflow.name) do |hash|
           set.add hash['id'], hash['priority']
         end
       end

--- a/lib/cellect/server/workflow.rb
+++ b/lib/cellect/server/workflow.rb
@@ -59,7 +59,7 @@ module Cellect
       def reload_data
         if can_reload_data?
           self.state = :reloading
-          Loader.new(self).future.reload_data
+          Loader.new(self).future.reload_data(set_klass.new)
         end
       end
 

--- a/lib/cellect/server/workflow.rb
+++ b/lib/cellect/server/workflow.rb
@@ -59,7 +59,8 @@ module Cellect
       def reload_data
         if can_reload_data?
           self.state = :reloading
-          data_loader.async.reload_data(set_klass.new)
+          reload_set = subjects.class.new
+          data_loader.async.reload_data(reload_set)
         end
       end
 

--- a/lib/cellect/server/workflow.rb
+++ b/lib/cellect/server/workflow.rb
@@ -52,14 +52,14 @@ module Cellect
       def load_data
         return if [:loading, :ready ].include? state
         self.state = :loading
-        Loader.new(self).async.load_data
+        data_loader.async.load_data
       end
 
       # Reloads subjects from the adapter
       def reload_data
         if can_reload_data?
           self.state = :reloading
-          Loader.new(self).future.reload_data(set_klass.new)
+          data_loader.async.reload_data(set_klass.new)
         end
       end
 
@@ -184,6 +184,10 @@ module Cellect
 
       def set_reload_at_time(time_stamp=Time.now + RELOAD_TIMEOUT)
         self.can_reload_at = time_stamp
+      end
+
+      def data_loader
+        Loader.new(self)
       end
     end
   end

--- a/spec/cellect/server/grouped_loader_spec.rb
+++ b/spec/cellect/server/grouped_loader_spec.rb
@@ -1,0 +1,14 @@
+require 'spec_helper'
+
+module Cellect::Server
+  describe Loader do
+    SET_TYPES.collect{ |type| "grouped_#{ type }" }.each do |workflow_type|
+      it_behaves_like "loader" do
+        let(:workflow) { GroupedWorkflow.new(workflow_type) }
+        let(:loader) { GroupedLoader.new(workflow) }
+        let(:subjects) { {} }
+        let(:load_method) { :[]= }
+      end
+    end
+  end
+end

--- a/spec/cellect/server/grouped_loader_spec.rb
+++ b/spec/cellect/server/grouped_loader_spec.rb
@@ -7,7 +7,40 @@ module Cellect::Server
         let(:workflow) { GroupedWorkflow.new(workflow_type) }
         let(:loader) { GroupedLoader.new(workflow) }
         let(:subjects) { {} }
-        let(:load_method) { :[]= }
+        let(:group_counts) do
+          fixtures.map { |f| f["group_id"] }.uniq.count
+        end
+
+        describe "#load_data" do
+          it "should setup the groups" do
+            expect(workflow.subjects)
+              .to receive(:[]=)
+              .exactly(group_counts)
+              .and_call_original
+            loader.load_data
+          end
+
+          it "should add data to the workflow subjects" do
+            set = workflow.set_klass.new
+            allow(workflow.set_klass)
+              .to receive(:new)
+              .and_return(set)
+            expect(set)
+              .to receive(:add)
+              .exactly(fixture_count)
+            loader.load_data
+          end
+        end
+
+        describe "#reload_data" do
+          it "should add data to the workflow subjects" do
+            expect(subjects)
+              .to receive(:[]=)
+              .exactly(group_counts)
+              .and_call_original
+            loader.reload_data(subjects)
+          end
+        end
       end
     end
   end

--- a/spec/cellect/server/loader_spec.rb
+++ b/spec/cellect/server/loader_spec.rb
@@ -1,0 +1,66 @@
+require 'spec_helper'
+
+module Cellect::Server
+  describe Loader do
+    SET_TYPES.each do |workflow_type|
+      let(:workflow) { Workflow.new(workflow_type) }
+      let(:loader) { Loader.new(workflow) }
+      let(:fixture_count) do
+        Cellect::Server
+          .adapter
+          .fixtures
+          .fetch(workflow.name, { })
+          .fetch('entries', [])
+          .count
+      end
+
+      describe "#load_data" do
+        it "should use the server adapter to load data" do
+          expect(Cellect::Server.adapter)
+            .to receive(:load_data_for)
+            .with(workflow.name)
+            .and_call_original
+          loader.load_data
+        end
+
+        it "should add data to the workflow subjects" do
+          expect(workflow.subjects)
+            .to receive(:add)
+            .exactly(fixture_count)
+          loader.load_data
+        end
+
+        it "should mark the workflow as loaded" do
+          expect { loader.load_data }.to change { workflow.state }.to(:ready)
+        end
+      end
+
+      describe "#reload_data" do
+        let(:subjects) { workflow.set_klass.new }
+
+        it "should add data to the workflow subjects" do
+          expect(subjects)
+            .to receive(:add)
+            .exactly(fixture_count)
+          loader.reload_data(subjects)
+        end
+
+        it "should replace the existing subjects with the reloaded set" do
+          expect {
+            loader.reload_data(subjects)
+          }.to change {
+            workflow.subjects
+          }.to(subjects)
+        end
+
+        it "should mark the workflow as ready" do
+          expect {
+            loader.reload_data(subjects)
+          }.to change {
+            workflow.state
+          }.to(:ready)
+        end
+      end
+    end
+  end
+end

--- a/spec/cellect/server/loader_spec.rb
+++ b/spec/cellect/server/loader_spec.rb
@@ -3,63 +3,11 @@ require 'spec_helper'
 module Cellect::Server
   describe Loader do
     SET_TYPES.each do |workflow_type|
-      let(:workflow) { Workflow.new(workflow_type) }
-      let(:loader) { Loader.new(workflow) }
-      let(:fixture_count) do
-        Cellect::Server
-          .adapter
-          .fixtures
-          .fetch(workflow.name, { })
-          .fetch('entries', [])
-          .count
-      end
-
-      describe "#load_data" do
-        it "should use the server adapter to load data" do
-          expect(Cellect::Server.adapter)
-            .to receive(:load_data_for)
-            .with(workflow.name)
-            .and_call_original
-          loader.load_data
-        end
-
-        it "should add data to the workflow subjects" do
-          expect(workflow.subjects)
-            .to receive(:add)
-            .exactly(fixture_count)
-          loader.load_data
-        end
-
-        it "should mark the workflow as loaded" do
-          expect { loader.load_data }.to change { workflow.state }.to(:ready)
-        end
-      end
-
-      describe "#reload_data" do
+      it_behaves_like "loader" do
+        let(:workflow) { Workflow.new(workflow_type) }
+        let(:loader) { Loader.new(workflow) }
         let(:subjects) { workflow.set_klass.new }
-
-        it "should add data to the workflow subjects" do
-          expect(subjects)
-            .to receive(:add)
-            .exactly(fixture_count)
-          loader.reload_data(subjects)
-        end
-
-        it "should replace the existing subjects with the reloaded set" do
-          expect {
-            loader.reload_data(subjects)
-          }.to change {
-            workflow.subjects
-          }.to(subjects)
-        end
-
-        it "should mark the workflow as ready" do
-          expect {
-            loader.reload_data(subjects)
-          }.to change {
-            workflow.state
-          }.to(:ready)
-        end
+        let(:load_method) { :add }
       end
     end
   end

--- a/spec/cellect/server/loader_spec.rb
+++ b/spec/cellect/server/loader_spec.rb
@@ -7,7 +7,24 @@ module Cellect::Server
         let(:workflow) { Workflow.new(workflow_type) }
         let(:loader) { Loader.new(workflow) }
         let(:subjects) { workflow.set_klass.new }
-        let(:load_method) { :add }
+
+        describe "#load_data" do
+          it "should add data to the workflow subjects" do
+            expect(workflow.subjects)
+              .to receive(:add)
+              .exactly(fixture_count)
+            loader.load_data
+          end
+        end
+
+        describe "#reload_data" do
+          it "should add data to the workflow subjects" do
+            expect(subjects)
+              .to receive(:add)
+              .exactly(fixture_count)
+            loader.reload_data(subjects)
+          end
+        end
       end
     end
   end

--- a/spec/support/shared_examples_for_loader.rb
+++ b/spec/support/shared_examples_for_loader.rb
@@ -1,12 +1,12 @@
 shared_examples_for 'loader' do |name|
-  let(:fixture_count) do
+  let(:fixtures) do
     Cellect::Server
       .adapter
       .fixtures
       .fetch(workflow.name, { })
       .fetch('entries', [])
-      .count
   end
+  let(:fixture_count) { fixtures.count }
 
   describe "#load_data" do
     it "should use the server adapter to load data" do
@@ -17,26 +17,12 @@ shared_examples_for 'loader' do |name|
       loader.load_data
     end
 
-    it "should add data to the workflow subjects" do
-      expect(workflow.subjects)
-        .to receive(load_method)
-        .exactly(fixture_count)
-      loader.load_data
-    end
-
     it "should mark the workflow as loaded" do
       expect { loader.load_data }.to change { workflow.state }.to(:ready)
     end
   end
 
   describe "#reload_data" do
-    it "should add data to the workflow subjects" do
-      expect(subjects)
-        .to receive(load_method)
-        .exactly(fixture_count)
-      loader.reload_data(subjects)
-    end
-
     it "should replace the existing subjects with the reloaded set" do
       expect {
         loader.reload_data(subjects)

--- a/spec/support/shared_examples_for_loader.rb
+++ b/spec/support/shared_examples_for_loader.rb
@@ -1,0 +1,56 @@
+shared_examples_for 'loader' do |name|
+  let(:fixture_count) do
+    Cellect::Server
+      .adapter
+      .fixtures
+      .fetch(workflow.name, { })
+      .fetch('entries', [])
+      .count
+  end
+
+  describe "#load_data" do
+    it "should use the server adapter to load data" do
+      expect(Cellect::Server.adapter)
+        .to receive(:load_data_for)
+        .with(workflow.name)
+        .and_call_original
+      loader.load_data
+    end
+
+    it "should add data to the workflow subjects" do
+      expect(workflow.subjects)
+        .to receive(load_method)
+        .exactly(fixture_count)
+      loader.load_data
+    end
+
+    it "should mark the workflow as loaded" do
+      expect { loader.load_data }.to change { workflow.state }.to(:ready)
+    end
+  end
+
+  describe "#reload_data" do
+    it "should add data to the workflow subjects" do
+      expect(subjects)
+        .to receive(load_method)
+        .exactly(fixture_count)
+      loader.reload_data(subjects)
+    end
+
+    it "should replace the existing subjects with the reloaded set" do
+      expect {
+        loader.reload_data(subjects)
+      }.to change {
+        workflow.subjects
+      }.to(subjects)
+    end
+
+    it "should mark the workflow as ready" do
+      expect {
+        loader.reload_data(subjects)
+      }.to change {
+        workflow.state
+      }.to(:ready)
+    end
+  end
+end

--- a/spec/support/shared_examples_for_workflow.rb
+++ b/spec/support/shared_examples_for_workflow.rb
@@ -22,7 +22,7 @@ shared_examples_for 'workflow' do |name|
     expect(obj.users.keys).to include 1
   end
 
-  context "with a celloid stubbed async loader" do
+  context "with a celluloid stubbed async loader" do
     let(:loader) { Cellect::Server::Loader.new(obj) }
     let(:celluloid_target) { loader.wrapped_object }
 

--- a/spec/support/shared_examples_for_workflow.rb
+++ b/spec/support/shared_examples_for_workflow.rb
@@ -58,7 +58,9 @@ shared_examples_for 'workflow' do |name|
         end
 
         it 'should request data from the loader' do
-          expect(celluloid_target).to receive(:reload_data)
+          expect(celluloid_target)
+            .to receive(:reload_data)
+            .with(instance_of(obj.subjects.class))
           obj.reload_data
         end
 

--- a/spec/support/shared_examples_for_workflow.rb
+++ b/spec/support/shared_examples_for_workflow.rb
@@ -23,7 +23,13 @@ shared_examples_for 'workflow' do |name|
   end
 
   context "with a celluloid stubbed async loader" do
-    let(:loader) { Cellect::Server::Loader.new(obj) }
+    let(:loader) do
+      if obj.grouped?
+        Cellect::Server::GroupedLoader.new(obj)
+      else
+        Cellect::Server::Loader.new(obj)
+      end
+    end
     let(:celluloid_target) { loader.wrapped_object }
 
     before do

--- a/spec/support/spec_adapter.rb
+++ b/spec/support/spec_adapter.rb
@@ -10,7 +10,12 @@ class SpecAdapter < Cellect::Server::Adapters::Default
   end
 
   def load_data_for(workflow_name)
-    fixtures.fetch(workflow_name, { }).fetch 'entries', []
+    entries = fixtures.fetch(workflow_name, { }).fetch 'entries', []
+    if block_given?
+      entries.each { |entry| yield entry }
+    else
+      entries
+    end
   end
 
   def fixtures


### PR DESCRIPTION
Use loader instances to load data asynchronously. This frees up the workflow object to respond to requests without blocking waiting for data to load. 