### PR TITLE
bump major version

### DIFF
--- a/lib/cellect/version.rb
+++ b/lib/cellect/version.rb
@@ -1,3 +1,3 @@
 module Cellect
-  VERSION = '2.1.1'
+  VERSION = '3.0.0'
 end


### PR DESCRIPTION
Incompatible api change that now uses a block to yield for incremental loading in the adapter, see spec_adapter.rb for details. Now with non-blocking async data loading and guards on loading / reload.