### PR TITLE
don't error if we can't find the workflow

### DIFF
--- a/lib/cellect/server/workflow.rb
+++ b/lib/cellect/server/workflow.rb
@@ -17,7 +17,9 @@ module Cellect
       # Look up and/or load a workflow
       def self.[](name)
         Cellect::Server.adapter.load_workflows(name) unless Actor[name]
-        Actor[name].actors.first
+        if registered_workflow = Actor[name]
+          registered_workflow.actors.first
+        end
       end
 
       # Load a workflow

--- a/spec/cellect/server/workflow_spec.rb
+++ b/spec/cellect/server/workflow_spec.rb
@@ -7,6 +7,11 @@ module Cellect::Server
       Workflow['random']
     end
 
+    it "should not raise error if no workflow exists to register" do
+      expect(Cellect::Server.adapter).to receive(:workflow_list).and_return([])
+      expect { Workflow['missing'] }.not_to raise_error
+    end
+
     SET_TYPES.each do |workflow_type|
       context workflow_type do
         let(:workflow) { Workflow.new(workflow_type) }


### PR DESCRIPTION
handle when the adapter can't load a workflow for registration