### PR TITLE
respect group_id when selecting data

### DIFF
--- a/lib/cellect/server/grouped_workflow.rb
+++ b/lib/cellect/server/grouped_workflow.rb
@@ -12,9 +12,18 @@ module Cellect
         subjects
       end
 
-      # Returns a group by id or samples one randomly with a fall back to a new group
+      # Returns a group by id
+      # if the group_id is supplied it will select this group
+      # and load data if no group is know, however when
+      # no group_id supplies, it selects a group at random
+      # with an overall fall back to a new group if no groups exist
       def group(group_id = nil)
-        subjects[group_id] || subjects.values.sample || fetch_or_setup_group(group_id)
+        group = if group_id
+                  fetch_or_setup_group(group_id)
+                else
+                  subjects.values.sample
+                end
+        group || fetch_or_setup_group(group_id)
       end
 
       # Get unseen subjects from a group for a user

--- a/spec/cellect/server/grouped_workflow_spec.rb
+++ b/spec/cellect/server/grouped_workflow_spec.rb
@@ -94,6 +94,12 @@ module Cellect::Server
             expect(workflow.group(1)).to receive(:subtract).with user.seen, 3
             workflow.sample user_id: 123, group_id: 1, limit: 3
           end
+
+          it 'should should select from an empty set if the group is not loaded' do
+            workflow.groups[0] = set_klass.new
+            expect(workflow.group(0)).not_to receive(:sample)
+            workflow.sample group_id: 1, limit: 3
+          end
         end
 
         describe "#add" do


### PR DESCRIPTION
Some subject sets are not available as they may be all retired / empty. Now we should not randomly select from a group when asking for specific group data. Instead, set an empty set_klass for that group and sample from this empty set. If no group is passed in then randomly select data.